### PR TITLE
Reference built image instead of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o action
 # ---------------
 FROM gcr.io/distroless/static:latest
 
-LABEL org.opencontainers.image.source=https://github.com/rode/github-actions/create-build-occurrence
+LABEL org.opencontainers.image.source=https://github.com/rode/create-build-occurrence-action
 
 COPY --from=builder /workspace/action /usr/local/bin/action
 

--- a/action.yaml
+++ b/action.yaml
@@ -7,7 +7,7 @@ branding:
 
 runs:
   using: docker
-  image: Dockerfile
+  image: docker://ghcr.io/rode/create-build-occurrence-action:latest
   env:
     ARTIFACT_ID: ${{ inputs.artifactId }}
     ARTIFACT_NAMES: ${{ inputs.artifactNames }}


### PR DESCRIPTION
Rather than rebuilding on every single run, run the pre-built image. 

Here's a [run against this branch](https://github.com/rode/demo-app/runs/2522661904?check_suite_focus=true). 