### PR TITLE
Improve connection error message and fail on non-temporary dial errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func (s *staticCredential) RequireTransportSecurity() bool {
 func newBuildCollectorClient(c *config) (*grpc.ClientConn, collector.BuildCollectorClient) {
 	dialOptions := []grpc.DialOption{
 		grpc.WithBlock(),
+		grpc.FailOnNonTempDialError(true),
 	}
 	if c.BuildCollector.Insecure {
 		dialOptions = append(dialOptions, grpc.WithInsecure())
@@ -91,7 +92,7 @@ func newBuildCollectorClient(c *config) (*grpc.ClientConn, collector.BuildCollec
 	defer cancel()
 	conn, err := grpc.DialContext(ctx, c.BuildCollector.Host, dialOptions...)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Unable to connect to build collector: %v", err)
 	}
 
 	return conn, collector.NewBuildCollectorClient(conn)


### PR DESCRIPTION
Previously if `buildCollectorHost` didn't contain a port, gRPC would continue trying to dial up until the timeout, which also had the effect of eating the original error message. This PR improves the message that's logged when there's a connection error, and sets the `grpc.FailOnNonTempDialError` dial option, so that it fails immediately and gives more information.

Before:
```
2021/08/27 08:55:04 context deadline exceeded
```

After:
```
2021/08/27 08:54:44 Unable to connect to build collector: connection error: desc = "transport: error while dialing: dial tcp: address build-collector-grpc.services.liatr.io: missing port in address"
``` 